### PR TITLE
Support duplicate Svelte component names at different paths

### DIFF
--- a/cmd/web/home.templ
+++ b/cmd/web/home.templ
@@ -6,10 +6,10 @@ templ Home() {
 		@Nav()
 		<div class="boxes">
 			<div class="box">
-				@Svelte("BoxOne", []byte(homeProps()))
+				@Svelte("lib/BoxOne", []byte(homeProps()))
 			</div>
 			<div class="box">
-				@Svelte("BoxTwo", nil)
+				@Svelte("lib/BoxTwo", nil)
 			</div>
 		</div>
 	}

--- a/cmd/web/htmx_handler.go
+++ b/cmd/web/htmx_handler.go
@@ -17,10 +17,10 @@ func HTMXHandler(w http.ResponseWriter, r *http.Request) {
 
 func getRandomComponent() templ.Component {
 	components := []templ.Component{
-		Svelte("BoxOne", nil),
-		Svelte("BoxTwo", nil),
-		Svelte("BoxThree", nil),
-		Svelte("ModeBox", []byte(`{"text": "I got picked randomly!"}`)),
+		Svelte("lib/BoxOne", nil),
+		Svelte("lib/BoxTwo", nil),
+		Svelte("lib/BoxThree", nil),
+		Svelte("lib/ModeBox", []byte(`{"text": "I got picked randomly!"}`)),
 	}
 
 	return components[rand.Intn(len(components))]

--- a/cmd/web/modes.templ
+++ b/cmd/web/modes.templ
@@ -21,10 +21,10 @@ templ Modes() {
 					</div>
 				</div>
 				<div class="basis-1/3">
-					@Svelte("ModeBox", []byte(`{"text": "SSR + Hydration"}`))
+					@Svelte("lib/ModeBox", []byte(`{"text": "SSR + Hydration"}`))
 				</div>
 				<div class="basis-1/3">
-					@Svelte("ModeBox", []byte(`{"text": "CSR Only"}`), Options{"mode": "csr"})
+					@Svelte("lib/ModeBox", []byte(`{"text": "CSR Only"}`), Options{"mode": "csr"})
 				</div>
 			</div>
 		</div>

--- a/cmd/web/nested.templ
+++ b/cmd/web/nested.templ
@@ -5,7 +5,19 @@ templ Nested() {
 		<h1>Nested Svelte Components</h1>
 		@Nav()
 		<div class="max-w-3xl">
-			@Svelte("Nested", nil)
+			<h2 class="text-2xl mb-5">Nested within Svelte</h2>
+			@Svelte("lib/Nested", nil)
+		</div>
+		<h2 class="mt-12 text-2xl mb-5">
+			Different components with the same name under different paths
+		</h2>
+		<div class="max-w-3xl flex gap-5">
+			<div>
+				@Svelte("lib/Button", nil)
+			</div>
+			<div>
+				@Svelte("lib/dir/Button", nil)
+			</div>
 		</div>
 	}
 }

--- a/cmd/web/page.templ
+++ b/cmd/web/page.templ
@@ -6,10 +6,10 @@ templ Page() {
 		@Nav()
 		<div class="boxes">
 			<div class="box">
-				@Svelte("BoxTwo", nil)
+				@Svelte("lib/BoxTwo", nil)
 			</div>
 			<div class="box">
-				@Svelte("BoxThree", nil)
+				@Svelte("lib/BoxThree", nil)
 			</div>
 		</div>
 	}

--- a/cmd/web/trello_clone.templ
+++ b/cmd/web/trello_clone.templ
@@ -15,18 +15,16 @@ func props() []byte {
 templ TrelloClone() {
 	@Base() {
 		<h1>sveltempl</h1>
-
 		@Nav()
-
 		<div class="box max-w-[814px] flex flex-col gap-4 mx-auto">
 			<p>Try dragging items or whole columns. <em><strong class="text-yellow-400">Svelte</strong></em> makes achieving this type of UI easy.</p>
 			<p>
-				<em><strong class="text-yellow-400">Sveltempl</strong></em>, on the other hand, makes server rendering and sharing state between client and server easy. Your front-end Svelte code will be identical to what it would be in an SPA or traditional "Islands" setup, just without the pesky network/api code!</p>
+				<em><strong class="text-yellow-400">Sveltempl</strong></em>, on the other hand, makes server rendering and sharing state between client and server easy. Your front-end Svelte code will be identical to what it would be in an SPA or traditional "Islands" setup, just without the pesky network/api code!
+			</p>
 			<p class="text-gray-400">
 				<em>Go ahead, Giv'er a <strong class="text-yellow-400">refresh!</strong> How about a private tab or <strong class="text-yellow-400">another browser</strong>?</em>
 			</p>
 		</div>
-
-		@Svelte("TrelloClone", props())
+		@Svelte("lib/TrelloClone", props())
 	}
 }

--- a/internal/codegen/svelte_types.go
+++ b/internal/codegen/svelte_types.go
@@ -13,21 +13,43 @@ type components map[string]string
 
 var ComponentMap = populateComponentMap("cmd/web/assets/svelte/")
 
+// populateComponentMap recursively traverses the given directory and populates the component map
 func populateComponentMap(dir string) components {
 	compMap := make(components)
+	err := traverseDirectory(dir, compMap)
+	if err != nil {
+		log.Fatalf("Failed to populate component map: %v", err)
+	}
+	return compMap
+}
 
+func traverseDirectory(dir string, compMap components) error {
 	files, err := os.ReadDir(dir)
 	if err != nil {
-		log.Fatalf("Failed to read directory: %v", err)
+		return fmt.Errorf("failed to read directory %s: %v", dir, err)
 	}
 
 	for _, file := range files {
-		if !file.IsDir() {
+		filePath := filepath.Join(dir, file.Name())
+
+		if file.IsDir() {
+			// Recursively traverse subdirectories
+			if err := traverseDirectory(filePath, compMap); err != nil {
+				return err
+			}
+		} else {
 			filename := file.Name()
 			parts := strings.SplitN(filename, "-", 2)
 			if len(parts) == 2 {
 				key := parts[0]
-				value := filepath.Join(dir, filename)
+				value := filePath
+
+				// Extract the relative path
+				relPath, _ := filepath.Rel("cmd/web/assets/svelte", dir)
+				if relPath != "." {
+					key = filepath.Join(relPath, key)
+				}
+
 				compMap[key] = strings.TrimPrefix(value, "cmd/web")
 			} else {
 				fmt.Printf("Skipping file with unexpected name format: %s\n", filename)
@@ -35,5 +57,5 @@ func populateComponentMap(dir string) components {
 		}
 	}
 
-	return compMap
+	return nil
 }

--- a/internal/sveltempl/component.templ
+++ b/internal/sveltempl/component.templ
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"rogchap.com/v8go"
 	"sveltempl/internal/codegen"
@@ -72,7 +73,7 @@ func hydrationScript(componentName string, internalId string, mode string) strin
 	csrPath := codegen.ComponentMap[componentName]
 
 	if os.Getenv("SVELTEMPL_HMR") != "" {
-		csrPath = "http://localhost:5173/src/lib/" + componentName + ".svelte"
+		csrPath = "http://localhost:5173/src/" + componentName + ".svelte"
 	}
 
 	return fmt.Sprintf(`
@@ -99,20 +100,23 @@ func hydrationScript(componentName string, internalId string, mode string) strin
 	`, csrPath, componentName, internalId, mode)
 }
 
-func svelTemplRenderToString(componentName string, iso *v8go.Isolate, componentProps []byte) (string, error) {
+// ? componentQualName includes leading path info relative to svelte/src
+func svelTemplRenderToString(componentQualName string, iso *v8go.Isolate, componentProps []byte) (string, error) {
 	// Create a new Javascript context
 	ctx := v8go.NewContext(iso)
 
-	if componentName == "" {
+	if componentQualName == "" {
 		return "", fmt.Errorf("you must pass in a component name to render")
 	}
+
+	componentName := path.Base(componentQualName)
 
 	// Construct the file path using fmt.Sprintf for string interpolation
 	cwd, err := os.Getwd()
 	if err != nil {
 		log.Fatalf("Failed to get current working directory: %v", err)
 	}
-	componentPath := filepath.Join(cwd, "svelte/dist-ssr-go", fmt.Sprintf("%s.js", componentName))
+	componentPath := filepath.Join(cwd, "svelte/dist-ssr-go", fmt.Sprintf("%s.js", componentQualName))
 
 	// Read the JavaScript file from disk
 	componentScript, err := os.ReadFile(componentPath)

--- a/svelte/src/lib/Button.svelte
+++ b/svelte/src/lib/Button.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  function handleClick() {
+    alert("I am the button");
+  }
+</script>
+
+<button on:click={handleClick}>The Button</button>

--- a/svelte/src/lib/dir/Button.svelte
+++ b/svelte/src/lib/dir/Button.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  function handleClick() {
+    alert("I am the nested button");
+  }
+</script>
+
+<button on:click={handleClick}>The Nested Button</button>

--- a/svelte/src/main.ts
+++ b/svelte/src/main.ts
@@ -1,2 +1,2 @@
-// ! why on earth does this work?
-[].forEach((name) => import(`./lib/${name}.svelte`));
+const modules = import.meta.glob("./lib/**/*.svelte");
+Object.keys(modules).forEach((path) => modules[path]());

--- a/svelte/vite.config.ssr.ts
+++ b/svelte/vite.config.ssr.ts
@@ -1,6 +1,6 @@
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { readdirSync, statSync } from "fs";
-import { basename, join, resolve } from "path";
+import { join, resolve } from "path";
 import { defineConfig } from "vite";
 import iifeBundle from "./iife-custom-plugin";
 
@@ -17,11 +17,12 @@ function getAllSvelteComponents(dir: string, fileList: string[] = []) {
   return fileList;
 }
 
-// Find all Svelte components in the src/lib directory
-const componentFiles = getAllSvelteComponents(resolve(__dirname, "src/lib"));
+// Find all Svelte components in the src directory
+const srcDir = resolve(__dirname, "src");
+const componentFiles = getAllSvelteComponents(srcDir);
 
 const input = componentFiles.reduce((acc, file) => {
-  const name = basename(file, ".svelte"); // Use the base name without the directory
+  const name = file.replace(srcDir, "").replace(".svelte", "").replace("/", "");
   acc[name] = resolve(__dirname, file);
   return acc;
 }, {} as Record<string, string>);

--- a/svelte/vite.config.ts
+++ b/svelte/vite.config.ts
@@ -1,4 +1,5 @@
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { resolve } from "path";
 import { defineConfig } from "vite";
 import cleanCopy from "./clean-copy-custom-plugin";
 
@@ -12,6 +13,20 @@ export default defineConfig({
   build: {
     rollupOptions: {
       input: "./src/main.ts",
+      output: {
+        dir: "dist",
+        format: "es",
+        chunkFileNames: ({ facadeModuleId }) => {
+          if (facadeModuleId) {
+            const name = facadeModuleId
+              .replace(resolve(__dirname, "src") + "/", "")
+              .replace(".svelte", "");
+            return `${name}-[hash].js`;
+          } else {
+            return `[name]-[hash].js`;
+          }
+        },
+      },
     },
   },
 });


### PR DESCRIPTION
Support duplicate component names at different paths.

This commit converts dist, dist-ssr, dist-ssr-go, and the sveltempl component map to hierarchical, preserving paths from the original Svelte component in src.

The vite/rollup config should be entirely split out into plugin scope in the near future, and take arguments for directories.