### PR TITLE
simplify js bundle location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Svelte built files
-/cmd/web/assets/svelte
+/cmd/web/assets/js/client
 
 # Tailwind built files
 output.css

--- a/internal/codegen/svelte_types.go
+++ b/internal/codegen/svelte_types.go
@@ -11,7 +11,7 @@ import (
 // TODO make type-safe in a way that provides IDE completions
 type components map[string]string
 
-var ComponentMap = populateComponentMap("cmd/web/assets/svelte/")
+var ComponentMap = populateComponentMap("cmd/web/assets/js/client")
 
 // populateComponentMap recursively traverses the given directory and populates the component map
 func populateComponentMap(dir string) components {
@@ -45,7 +45,7 @@ func traverseDirectory(dir string, compMap components) error {
 				value := filePath
 
 				// Extract the relative path
-				relPath, _ := filepath.Rel("cmd/web/assets/svelte", dir)
+				relPath, _ := filepath.Rel("cmd/web/assets/js/client", dir)
 				if relPath != "." {
 					key = filepath.Join(relPath, key)
 				}

--- a/internal/sveltempl/component.templ
+++ b/internal/sveltempl/component.templ
@@ -116,7 +116,7 @@ func svelTemplRenderToString(componentQualName string, iso *v8go.Isolate, compon
 	if err != nil {
 		log.Fatalf("Failed to get current working directory: %v", err)
 	}
-	componentPath := filepath.Join(cwd, "svelte/dist-ssr-go", fmt.Sprintf("%s.js", componentQualName))
+	componentPath := filepath.Join(cwd, "svelte/dist/ssr-go", fmt.Sprintf("%s.js", componentQualName))
 
 	// Read the JavaScript file from disk
 	componentScript, err := os.ReadFile(componentPath)

--- a/svelte/.gitignore
+++ b/svelte/.gitignore
@@ -9,8 +9,6 @@ lerna-debug.log*
 
 node_modules
 /dist
-/dist-ssr
-/dist-ssr-go
 *.local
 
 # Editor directories and files

--- a/svelte/clean-copy-custom-plugin.ts
+++ b/svelte/clean-copy-custom-plugin.ts
@@ -16,7 +16,7 @@ export default function cleanCopy(relativePath: string) {
       fs.mkdirSync(targetDir, { recursive: true });
 
       // Copy files
-      const srcDir = path.resolve(__dirname, "./dist");
+      const srcDir = path.resolve(__dirname, "./dist/client");
       const fileList = getFilePathsRecursive(srcDir);
 
       fileList.forEach((file) => {

--- a/svelte/iife-custom-plugin.ts
+++ b/svelte/iife-custom-plugin.ts
@@ -10,7 +10,7 @@ type Options = {
 };
 
 export default function iifeBundle(options: Options = {}): Plugin {
-  const { outputDir = "dist-ssr-go", inputDir = "dist-ssr" } = options;
+  const { outputDir = "dist/ssr-go", inputDir = "dist/ssr" } = options;
 
   return {
     name: "sveltempl-iife-bundle",

--- a/svelte/vite.config.ssr.ts
+++ b/svelte/vite.config.ssr.ts
@@ -31,8 +31,8 @@ export default defineConfig({
   plugins: [
     svelte(),
     iifeBundle({
-      outputDir: "dist-ssr-go",
-      inputDir: "dist-ssr",
+      outputDir: "dist/ssr-go",
+      inputDir: "dist/ssr",
     }),
   ],
   build: {
@@ -40,7 +40,7 @@ export default defineConfig({
     rollupOptions: {
       input,
       output: {
-        dir: "dist-ssr",
+        dir: "dist/ssr",
       },
     },
   },

--- a/svelte/vite.config.ts
+++ b/svelte/vite.config.ts
@@ -8,13 +8,13 @@ export default defineConfig({
     svelte({
       emitCss: false,
     }),
-    cleanCopy("../cmd/web/assets/svelte"),
+    cleanCopy("../cmd/web/assets/js/client"),
   ],
   build: {
     rollupOptions: {
       input: "./src/main.ts",
       output: {
-        dir: "dist",
+        dir: "dist/client",
         format: "es",
         chunkFileNames: ({ facadeModuleId }) => {
           if (facadeModuleId) {


### PR DESCRIPTION
It might be easier to throw the generated JS files under a singular directory that can be easier to reference and/or cleaned

**Changes** 
- Groups all the generated JS files within the `dist/` directory rather than having 3 separate directories. 
- Updates the location/name of the copied svelte contents to `web/assets/svelte` to `web/assets/js/client` (this is personal preference -> feel free to reject this change)